### PR TITLE
Add simple backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Cicada Backend
+
+This repository contains a small static website. A minimal Express backend has been added to provide an `alive` endpoint so that clients can verify that the server is running.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Start the server:
+   ```bash
+   npm start
+   ```
+
+The server listens on port `3000` by default (or the value of the `PORT` environment variable).
+
+## API
+
+`POST /alive`
+
+Returns a JSON object confirming that the backend is running:
+
+```json
+{ "status": "alive" }
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cicada-backend",
+  "version": "1.0.0",
+  "description": "Simple backend for alive check",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+
+// Simple POST endpoint to check if the backend is alive
+app.post('/alive', (req, res) => {
+  res.json({status: 'alive'});
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Express server with `/alive` POST
- document how to run the backend

## Testing
- `node server.js` *(fails: Cannot find module 'express')*